### PR TITLE
zephyr-doc-theme: restore breadcrumb nav header

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -107,6 +107,7 @@
       <div id="main">
         <!-- STARTS .main-container -->
         <div class="main-container">
+          {% include "breadcrumbs.html" %}
           <aside id="sidebar-first" class="container-sidebar">
             {# SIDE NAV, TOGGLES ON MOBILE #}
             {% include "sidebar.html" %}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2,6 +2,11 @@
   width: auto;
 }
 
+
+#breadcrumb {  /* dbk */
+  margin-bottom: 20px;
+}
+
 .page-documentation .docs-menu a {
   display: block;
   font-weight: normal;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3226,7 +3226,7 @@ div.status {
 }
 
 .page-documentation #main {
-  margin-top: 30px;
+  /* margin-top: 30px; dbk: for adding breadcrumb */
 }
 .page-documentation #main-content > div.container {
   min-height: 100vh;


### PR DESCRIPTION
breadcrumb navigation header was in the previous theme but was removed in the
new website. This provides a valuable navigation context reference. include
the breadcrumb navigation in the layout.html, and tweak the CSS to make room
between the site header and main content div (tweaks to custom.css and
main.css)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>