### PR TITLE
zephyr-doc-theme: blue hyperlinks

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -10,7 +10,7 @@
 
 .page-documentation .docs-menu .toctree-l1 > a.reference.internal::before {
   content: '\f0da';
-  color: #ba6de8;
+  color: #0070C5;     /* dbk blue not purple triangles ba6de8; */
 }
 
 .page-documentation .docs-menu .toctree-l1.current > a.reference.internal::before {
@@ -32,7 +32,7 @@
     top: 0;
     left: 35px;
     height: 100%;
-    border-left: 2px solid #ba6de8;
+    border-left: 2px solid #0070C5;   /* dbk blue not purple ba6de8; */
 }
 
 /*

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -6433,16 +6433,16 @@ a {
   font-weight: bold;
 }
 a:link {
-  color: #ba6de8;
+  color: #0070C5;  /* dbk blue instead of purple ba6de8; */
 }
 a:visited {
-  color: #ba6de8;
+  color: #0070C5;  /* dbk blue instead of purple ba6de8; */
 }
 a:hover, a:focus {
-  color: #9454db;
+  color: #338DD1;  /* dbk light-blue instead of purple 9454db; */
 }
 a:active {
-  color: #9454db;
+  color: #338DD1;  /* dbk light-blue instead of purple 9454db; */
 }
 
 div.caption-inner,


### PR DESCRIPTION
the new zephyr website theme uses a hot purple color for hyperlinks and is
rather distracting on pages with lots of links. A more traditional standard
color is blue and is more visually appealing. Link and side-bar navigation
colors are set in custom.css and main.css

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>