### PR TITLE
zephyr-doc-theme: light-gray code-block background

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3114,7 +3114,7 @@ pre {
   word-break: break-all;
   word-wrap: break-word;
   white-space: pre;
-  background-color: #a4e0f2;
+  background-color: #F0F0F0;  /* dbk light gray not blue background a4e0f2; */
 }
 pre.inline {
   display: inline;


### PR DESCRIPTION
new website color scheme uses a light blue background on code blocks. This
conflicts with the highlight color of notes and makes the notes less, well,
noteworthy. A gray background looks more in line with a technical doc.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>