### PR TITLE
zephyr-doc-theme: hyperlinks with normal weight

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -6430,7 +6430,7 @@ html {
 
 a {
   text-decoration: none;
-  font-weight: bold;
+  /* font-weight: bold;  dbk: regular weight, not bold */
 }
 a:link {
   color: #0070C5;  /* dbk blue instead of purple ba6de8; */


### PR DESCRIPTION
We're already coloring links, so having them with a bold weight makes them
stand out too much from the body text.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>