### PR TITLE
zephyr-doc-theme: move breadcrumb over content

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -5,6 +5,7 @@
 
 #breadcrumb {  /* dbk */
   margin-bottom: 20px;
+  margin-left: 24%;
 }
 
 .page-documentation .docs-menu a {


### PR DESCRIPTION
Rumor has it that breadcrumbs are generally displayed above the main
content and not over the left-nav column.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>