### PR TITLE
docs-theme: prep theme for moving docs server

### DIFF
--- a/breadcrumbs.html
+++ b/breadcrumbs.html
@@ -6,12 +6,20 @@
 {% set suffix = source_suffix %}
 {% endif %}
 
+<!-- {{ docs_title }} -->
+
+{# parameterize default name "Docs" in breadcrumb via docs_title in conf.py #}
+{% if not docs_title %}
+{% set docs_title = "Docs" %}
+{% endif %}
+
+
 <div id="breadcrumb">
   <div class="container">
     <a href="/">Home</a> / 
-    <a href="{{ pathto(master_doc) }}">Docs</a> / 
+    <a href="{{ pathto(master_doc) }}">{{ docs_title }}</a> /
       {% for doc in parents %}
-          <a href="{{ doc.link|e }}">{{ doc.title }}</a> / 
+          <a href="{{ doc.link|e }}">{{ doc.title }}</a> /
       {% endfor %}
   </div>
 </div>

--- a/header.html
+++ b/header.html
@@ -1,8 +1,8 @@
 <header id="header">
   <div class="header-wrapper">
     <div class="container">
-      <a href="/" title="Zephyr Project" rel="home" id="logo">
-        <img src="{{ pathto('_static/img/logo_white.png', 1) }}" alt="Zephyr Project"/>
+      <a href="https://zephyrproject.org/" title="Zephyr Project" rel="home" id="logo">
+        <img src="{{ pathto('_static/img/logo_white.png', 1) }}" alt="Zephyr Project">
       </a>
       <a href="" id="navigation-toggle">
         <span> </span>
@@ -10,8 +10,8 @@
       </a>
       <nav id="navigation" class="menu with-primary with-secondary">
         <ul class="header-menu secondary-menu">
-          <li class="first leaf join mid-2401"><a href="/about/join"><span>Join</span></a></li>
-          <li class="last leaf search mid-2402"><a href="/search" class="search-toggle"><span>Search</span></a></li>
+          <li class="first leaf join mid-2401"><a href="https://zephyrproject.org/about/join"><span>Join</span></a></li>
+          <li class="last leaf search mid-2402"><a href="https://zephyrproject.org/search" class="search-toggle"><span>Search</span></a></li>
         </ul>
         <div id="search-container">
           <form id="header-search-form" class="input-group">
@@ -29,42 +29,42 @@
           </form>
         </div>
         <ul class="header-menu main-menu">
-          <li class="first expanded about mid-1209"><a href="/about/what-is-zephyr-project" title="This link takes an user to the project's about page."><span>About</span></a>
+          <li class="first expanded about mid-1209"><a href="https://zephyrproject.org/about/what-is-zephyr-project" title="This link takes an user to the project's about page."><span>About</span></a>
             <ul class="menu">
-              <li class="first leaf what-is-zephyr- mid-2563"><a href="/about/what-is-zephyr-project"><span>What is Zephyr?</span></a></li>
-              <li class="leaf membership-list mid-2532"><a href="/about/membership-list"><span>Membership List</span></a></li>
-              <li class="leaf organization mid-2564"><a href="/about/organization"><span>Organization</span></a></li>
-              <li class="leaf faq mid-2525"><a href="/about/faq"><span>FAQ</span></a></li>
-              <li class="leaf contact-us mid-2530"><a href="/about/contact"><span>Contact Us</span></a></li>
-              <li class="last leaf releases mid-2622"><a href="/about/releases"><span>Releases</span></a></li>
+              <li class="first leaf what-is-zephyr- mid-2563"><a href="https://zephyrproject.org/about/what-is-zephyr-project"><span>What is Zephyr?</span></a></li>
+              <li class="leaf membership-list mid-2532"><a href="https://zephyrproject.org/about/membership-list"><span>Membership List</span></a></li>
+              <li class="leaf organization mid-2564"><a href="https://zephyrproject.org/about/organization"><span>Organization</span></a></li>
+              <li class="leaf faq mid-2525"><a href="https://zephyrproject.org/about/faq"><span>FAQ</span></a></li>
+              <li class="leaf contact-us mid-2530"><a href="https://zephyrproject.org/about/contact"><span>Contact Us</span></a></li>
+              <li class="last leaf releases mid-2622"><a href="https://zephyrproject.org/about/releases"><span>Releases</span></a></li>
             </ul>
           </li>
-          <li class="expanded documentation mid-2056"><a href="/doc/" title="This link takes an user to the project's documentation."><span>Documentation</span></a>
+          <li class="expanded documentation mid-2056"><a href="https://zephyrproject.org/doc/" title="This link takes you to the project's documentation."><span>Documentation</span></a>
             <ul class="menu">
-              <li class="first last leaf supported-boards mid-2621"><a href="/doc/boards/boards.html"><span>Supported Boards</span></a></li>
+              <li class="first last leaf supported-boards mid-2621"><a href="https://zephyrproject.org/doc/boards/boards.html"><span>Supported Boards</span></a></li>
             </ul>
           </li>
-          <li class="leaf downloads mid-1207"><a href="/downloads"><span>Downloads</span></a></li>
-          <li class="expanded community mid-2535"><a href="/community/how-to-contribute"><span>Community</span></a>
+          <li class="leaf downloads mid-1207"><a href="https://zephyrproject.org/downloads"><span>Downloads</span></a></li>
+          <li class="expanded community mid-2535"><a href="https://zephyrproject.org/community/how-to-contribute"><span>Community</span></a>
             <ul class="menu">
-              <li class="first leaf how-to-contribute mid-2534"><a href="/community/how-to-contribute"><span>How to Contribute</span></a></li>
-              <li class="last leaf community-guidelines mid-2129"><a href="/community/community-guidelines"><span>Community Guidelines</span></a></li>
+              <li class="first leaf how-to-contribute mid-2534"><a href="https://zephyrproject.org/community/how-to-contribute"><span>How to Contribute</span></a></li>
+              <li class="last leaf community-guidelines mid-2129"><a href="https://zephyrproject.org/community/community-guidelines"><span>Community Guidelines</span></a></li>
             </ul>
           </li>
-          <li class="expanded news mid-2131"><a href="/news/announcements"><span>News</span></a>
+          <li class="expanded news mid-2131"><a href="https://zephyrproject.org/news/announcements"><span>News</span></a>
             <ul class="menu">
-              <li class="first leaf announcements mid-2518"><a href="/news/announcements"><span>Announcements</span></a></li>
-              <li class="leaf blog mid-2378"><a href="/blog"><span>Blog</span></a></li>
-              <li class="last leaf events mid-2519"><a href="/news/events"><span>Events</span></a></li>
+              <li class="first leaf announcements mid-2518"><a href="https://zephyrproject.org/news/announcements"><span>Announcements</span></a></li>
+              <li class="leaf blog mid-2378"><a href="https://zephyrproject.org/blog"><span>Blog</span></a></li>
+              <li class="last leaf events mid-2519"><a href="https://zephyrproject.org/news/events"><span>Events</span></a></li>
             </ul>
           </li>
-          <li class="last expanded resources mid-2515"><a href="/resources"><span>Resources</span></a>
+          <li class="last expanded resources mid-2515"><a href="https://zephyrproject.org/resources"><span>Resources</span></a>
             <ul class="menu">
-              <li class="first leaf presentations mid-2517"><a href="/resources/presentations"><span>Presentations</span></a></li>
-              <li class="leaf demos mid-2526"><a href="/resources/demos"><span>Demos</span></a></li>
-              <li class="leaf videos mid-2516"><a href="/resources/videos"><span>Videos</span></a></li>
-              <li class="leaf real-life-examples mid-2527"><a href="/resources/real-life-examples"><span>Real Life Examples</span></a></li>
-              <li class="last leaf developer-tools mid-2528"><a href="/resources/developer-tools"><span>Developer Tools</span></a></li>
+              <li class="first leaf presentations mid-2517"><a href="https://zephyrproject.org/resources/presentations"><span>Presentations</span></a></li>
+              <li class="leaf demos mid-2526"><a href="https://zephyrproject.org/resources/demos"><span>Demos</span></a></li>
+              <li class="leaf videos mid-2516"><a href="https://zephyrproject.org/resources/videos"><span>Videos</span></a></li>
+              <li class="leaf real-life-examples mid-2527"><a href="https://zephyrproject.org/resources/real-life-examples"><span>Real Life Examples</span></a></li>
+              <li class="last leaf developer-tools mid-2528"><a href="https://zephyrproject.org/resources/developer-tools"><span>Developer Tools</span></a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
Prepare the docs theme for moving the docs away from zephyrproject.org and on
to a new docs.zephyrproject.org server by adjusting header links to not be
relative (e.g., /about changes to zephyrproject.org/about). This change can be
made now since it still works if the docs and main site are on the same
server.)

Also allow "Docs" in breadcrumb to be parameterized in conf.py (default remains
as "Docs") so when we regenerate docs for older releases we can include the
release version in the breadcrumb header.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>