### PR TITLE
theme: fix broken search for sphinx 1.5

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -142,7 +142,8 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
         };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
Sphinx 1.5 introduced a problem explained in
https://github.com/sphinx-doc/sphinx/pull/2454
that breaks the site search box.  This patch
(together with a conf.py patch in the zephyr repo
repairs things).

Jira: INF-136

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>