### PR TITLE
theme: links to heading display behind header

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -5,6 +5,15 @@
   box-sizing: border-box;
 }
 
+/* adjust title link target locations so they're not hidden behind the
+ * fixed header - dbk
+ */
+div.section[id], span[id] {
+  display: block;
+  padding-top: 100px;
+  margin-top: -100px;
+}
+
 article, aside, details, figcaption, figure, footer, header, hgroup, nav, section {
   display: block;
 }


### PR DESCRIPTION
Links to intra-page targets such as section headings
(with a #section-name) start behind the page header
and don't show the section heading.  This patch adds
some hidden padding that forces the section to display
lower on the page and visible below the heading.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>