### PR TITLE
theme: JS fix for link targets behind heading

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -5,15 +5,6 @@
   box-sizing: border-box;
 }
 
-/* adjust title link target locations so they're not hidden behind the
- * fixed header - dbk
- */
-div.section[id], span[id], dt[id] {
-  display: block;
-  padding-top: 100px;
-  margin-top: -100px;
-}
-
 article, aside, details, figcaption, figure, footer, header, hgroup, nav, section {
   display: block;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,7 +31,6 @@ $(window).on("load",function () {
   $('#secondary-menu-button').click(function() {
     $('#sidebar-first').toggleClass('-expanded-submenu');
   });
-
 });
 
 function doSearch(type, query) {
@@ -45,3 +44,32 @@ function doSearch(type, query) {
       break;
   }
 }
+
+/**
+ * Targets are hiding behind the fixed header
+ * Check an href for an anchor. If exists, and in document, scroll to it.
+ * If href argument ommitted, assumes context (this) is HTML Element,
+ * which will be the case when invoked by jQuery after an event
+ */
+function scroll_if_anchor(href) {
+    href = typeof(href) == "string" ? href : $(this).attr("href");
+    // Static value for now (maybe calculate header size dynamically?)
+    var fromTop = 90;
+    if(href.indexOf("#") == 0) { //i.e., target starts with a #
+        // need to escape any "." in the ID (darn doxygen links)
+        var $target = $(href.replace(/\./g, "\\."));
+        if($target.length) { // Watch for empty references (e.g., just a #)
+            $('html, body').animate({ scrollTop: $target.offset().top - fromTop });
+            if(history && "pushState" in history) {
+                history.pushState({}, document.title, window.location.pathname + href);
+                return false;
+            }
+        }
+    }
+}
+
+// When our page loads, check to see if it contains an anchor
+scroll_if_anchor(window.location.hash);
+
+// Intercept all anchor clicks
+$("body").on("click", "a", scroll_if_anchor);


### PR DESCRIPTION
The previous CSS-based fix using bounding box tricks ends up creating a
problem where nearby links could be hidden by the bounding box.  This
JS-based solution doesn't suffer from this problem.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>