### PR TITLE
theme: update "old version" warning

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -117,8 +117,8 @@
             {# PAGE CONTENT #}
 	    {% if is_release %}
 	    <div class="wy-alert wy-alert-danger">
-		    This is archived documentation for Zephyr version {{ version }}, and not
-                    <a href="/{{ pagename }}.html">the latest (master) documentation</a>.
+		    The <a href="/{{ pagename }}.html">latest development version</a>
+		    of this page may be more current than this released {{ version }} version.
 	    </div>
 	    {% endif %}
             <div class="rst-content">


### PR DESCRIPTION
The embedded link mentioned in the warning is to the latest version of
the page you're viewing (built from the master branch).  Note though,
that this will generate a 404 error if the old page no longer exists
because it was moved, renamed, or deleted.

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>