### PR TITLE
doc: add google analytics tracking code

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -20,6 +20,13 @@
 <html class="no-js" lang="en" > <!--<![endif]-->
   <head>
     <meta charset="utf-8">
+   <!-- Google Tag Manager -->
+   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+   })(window,document,'script','dataLayer','GTM-KMP8MS');</script>
+   <!-- End Google Tag Manager -->
     <link rel="apple-touch-icon" sizes="57x57" href="{{ pathto('_static/img/apple-touch-icon-57x57.png', 1) }}">
     <link rel="apple-touch-icon" sizes="60x60" href="{{ pathto('_static/img/apple-touch-icon-60x60.png', 1) }}">
     <link rel="apple-touch-icon" sizes="72x72" href="{{ pathto('_static/img/apple-touch-icon-72x72.png', 1) }}">
@@ -101,6 +108,10 @@
   </head>
 
   <body class="not-front page-documentation one-sidebar sidebar-first" role="document" >
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMP8MS"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="page">
       {% include "header.html" %}
       <!-- STARTS #main -->


### PR DESCRIPTION
Currently only zephyrproject.org hits are tracked with google analytics.
This patch adds tracking to the Sphinx-generated docs hosted on
docs.zephyrproject.org

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>